### PR TITLE
Make the site less terrible when there are no upcoming events

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,8 +5,12 @@ class RegistrationsController < ApplicationController
   before_filter :load_event
 
   def new
-    @registration = @event.registrations.build
-    respond_with @registration
+    if @event.ends_at.past?
+      render :registration_closed
+    else
+      @registration = @event.registrations.build
+      respond_with @registration
+    end
   end
 
   def create

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,10 +13,11 @@
     <h3 class="sub-section-title">Suggested Projects</h3>
     <p>Something that can be released in a weekend. Not a final version, but something to get it in front of people. Maybe you've been coding up a killer app, but need help building a website to announce it. Maybe you have a nasty bug you need help with. Maybe you need some copy written. Maybe you just need a few hours of encouragement. We'll get your project polished up and ready to go.<br>Bring a project, and get ready to ship it!</p>
   </div>
-        
+
   <div class="clearfix"></div>
 </article><!-- #article -->
 
+<% unless @current_event.ends_at.past? %>
 <article class="event">
   <header>
     <h2>Coming to</h2>
@@ -26,12 +27,14 @@
   <div class='partners'>
     <a href='http://collectiveidea.com'><%= image_tag "collectiveidea.png", height: 100, class: 'partner' %></a>
     <% if @current_event.sponsors.partner.present? %>
-      <span class='plus'>+</span> 
+      <span class='plus'>+</span>
       <a href='<%= @current_event.sponsors.partner.url %>'><%= image_tag @current_event.sponsors.partner.image.url, height: 100, class: 'partner' %></a>
     <% end %>
   </div>
 </article>
-<%= render 'shared/sponsors', event: @current_event %>    
+<% end %>
+
+<%= render 'shared/sponsors', event: @current_event %>
 <%= render 'shared/people', event: @current_event %>
 <%= render 'shared/schedule', event: @current_event %>
 <%= render 'shared/upcoming', events: @upcoming %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,11 +8,11 @@
   <%= content_for :javascripts %>
   <%= csrf_meta_tags %>
   <%= content_for :meta %>
-  
+
   <!--[if IE]>
   <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
-  
+
   <% if Rails.env.production? %>
   <script>
     var _gauges = _gauges || [];
@@ -37,7 +37,7 @@
       <h1>Finish Weekend</h1>
       <h2>This is your time to commit to launching something.<br>Bring a project, and get ready to ship it!.</h2>
     </header>
-    
+
     <section id="events">
       <div id="inner"></div>
       <div id="stationary">
@@ -47,7 +47,7 @@
           <a id="next">next finishweekend event</a>
         </div>
       </div>
-        
+
       <article id="event">
         <div id="location">
           <%= image_tag @current_event.image.url, width: 280, height: 123 if @current_event.image? %>
@@ -58,11 +58,11 @@
           <h2 id="state"><%= @current_event.state %></h2>
           <h1 id="date"><%= @current_event.starts_at.strftime "%B %d" %>–<%= @current_event.ends_at.strftime "%d" %></h1>
           <h2 id="address"><%= @current_event.address %></h2>
-        </div>            
+        </div>
       </article>
 
     </section><!-- #events -->
-    
+
     <section id="navigation">
       <nav>
         <h1 id="title"><%= link_to "Finish Weekend", root_path %></h1>
@@ -90,7 +90,7 @@
   </section><!-- #main-content -->
 
   <footer>
-  <small>© 2011–2012. Brought to you by <a href="http://collectiveidea.com">Collective Idea</a>. Questions? Get in touch with us at <a href="mailto:finishweekend@collectiveidea.com">finishweekend@collectiveidea.com</a>.</small>
+  <small>© 2011–<%= Date.current.year %>. Brought to you by <a href="http://collectiveidea.com">Collective Idea</a>. Questions? Get in touch with us at <a href="mailto:finishweekend@collectiveidea.com">finishweekend@collectiveidea.com</a>.</small>
   </footer>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,16 +49,22 @@
       </div>
 
       <article id="event">
-        <div id="location">
-          <%= image_tag @current_event.image.url, width: 280, height: 123 if @current_event.image? %>
-          <a id="register" href="<%= new_event_registration_path @current_event %>"><h1>Register</h1></a>
-        </div>
-        <div id="info">
-          <h1 id="city"><%= @current_event.name %></h1>
-          <h2 id="state"><%= @current_event.state %></h2>
-          <h1 id="date"><%= @current_event.starts_at.strftime "%B %d" %>–<%= @current_event.ends_at.strftime "%d" %></h1>
-          <h2 id="address"><%= @current_event.address %></h2>
-        </div>
+        <%- if @current_event.ends_at.past? -%>
+          <div id="info">
+            <h1>Stay Tuned!</h1>
+            <h2>After a break, we have new dates in the works. Watch this space!</h2>
+        <%- else -%>
+          <div id="location">
+            <%= image_tag @current_event.image.url, width: 280, height: 123 if @current_event.image? %>
+            <a id="register" href="<%= new_event_registration_path @current_event %>"><h1>Register</h1></a>
+          </div>
+          <div id="info">
+            <h1 id="city"><%= @current_event.name %></h1>
+            <h2 id="state"><%= @current_event.state %></h2>
+            <h1 id="date"><%= @current_event.starts_at.strftime "%B %d" %>–<%= @current_event.ends_at.strftime "%d" %></h1>
+            <h2 id="address"><%= @current_event.address %></h2>
+          </div>
+        <%- end -%>
       </article>
 
     </section><!-- #events -->

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -45,7 +45,7 @@
       <% @events.each do |event| %>
         <li class="<%= "active" if @event.slug == event.slug %>">
         <%= link_to event.name, manage_event_path(event) %>
-        </li> 
+        </li>
       <% end %>
     </ul>
     </aside>
@@ -53,7 +53,7 @@
     <%= yield %>
     </section>
     <footer>
-    © 2011 – 2012 Collective Idea
+    © 2011–<%= Date.current.year %> Collective Idea
     </footer>
     </section>
   </body>

--- a/app/views/layouts/session.html.erb
+++ b/app/views/layouts/session.html.erb
@@ -8,11 +8,11 @@
   <%= content_for :javascripts %>
   <%= csrf_meta_tags %>
   <%= content_for :meta %>
-  
+
   <!--[if IE]>
   <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
-  
+
   <link href='https://fonts.googleapis.com/css?family=Convergence|Patua+One' rel='stylesheet' type='text/css'>
 </head>
 <body class="management">
@@ -25,7 +25,7 @@
       </div>
     </div>
   </header>
-  
+
   <section class="container wrapper">
     <section id="flash">
       <% if flash[:notice] %>
@@ -39,7 +39,7 @@
       <%= yield %>
     </section>
     <footer>
-      © 2011 – 2012 Collective Idea
+      © 2011–<%= Date.current.year %> Collective Idea
     </footer>
   </section>
 </body>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <aside id="event-price">
   <span data-original-price="<%= @event.price %>">
-    <%= number_to_currency @event.price %> 
+    <%= number_to_currency @event.price %>
   </span>
   <p>Per Registration</p>
 </aside>

--- a/app/views/registrations/registration_closed.html.erb
+++ b/app/views/registrations/registration_closed.html.erb
@@ -1,0 +1,1 @@
+<p>Registration is now closed. We hope to see you at a future event!</p>

--- a/features/events.feature
+++ b/features/events.feature
@@ -19,7 +19,8 @@ Feature: events
   Scenario: last event scheduled is still on the home page
     Given it is "December 30, 2012"
     And I am on the homepage
-    Then I should see "Finish Weekend Future"
+    Then I should not see "Finish Weekend Future"
+    And I should see "Stay Tuned"
 
   Scenario: list of events
     Given it is "January 1, 2012"


### PR DESCRIPTION
This is a mostly-not-hackish way of showing that we don't have anything on the schedule today.  
Previously, it showed the last event without a year, which caused confusion.